### PR TITLE
Fix typo in docstring for `latsph`

### DIFF
--- a/src/l.jl
+++ b/src/l.jl
@@ -106,7 +106,7 @@ end
 """
     latsph(radius, lon, lat)
 
-Convert from latitudinal coordinates to rectangular coordinates.
+Convert from latitudinal coordinates to spherical coordinates.
 
 ### Arguments ###
 


### PR DESCRIPTION
The docstring for `latsph` says that it converts to rectangular coordinates, but it in fact converts to spherical coordinates as documented in the linked page for [`latsph_c`](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/latsph_c.html).