### PR TITLE
Fix bug in dsphdr

### DIFF
--- a/src/d.jl
+++ b/src/d.jl
@@ -2102,7 +2102,8 @@ function dsphdr(x, y, z)
     ccall((:dsphdr_c, libcspice), Cvoid,
           (SpiceDouble, SpiceDouble, SpiceDouble, Ref{SpiceDouble}),
           x, y, z, jacobi)
-    jacobi
+    handleerror()
+    permutedims(jacobi)
 end
 
 """


### PR DESCRIPTION
Fixes #23, but leaves a weak test, because it is not the only one (a symmetric matrix as expected).